### PR TITLE
Add LICENSE-BSD

### DIFF
--- a/LICENSE-BSD
+++ b/LICENSE-BSD
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021-present, Tobias Briones
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Copyright © 2021-present Tobias Briones. All rights reserved.
 ### License
 
 Content licensed under the [CC-BY-4.0 License](LICENSE-CC). Code licensed
-under the [MIT License](LICENSE-MIT).
+under the [BSD-3-Clause License](LICENSE-BSD).

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/module-mrm-canvas---uml-class-diagram.svg
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/module-mrm-canvas---uml-class-diagram.svg
@@ -1,7 +1,3 @@
-<!-- Copyright (c) 2022 Tobias Briones. All rights reserved. -->
-<!-- SPDX-License-Identifier: MIT -->
-<!-- This file is part of https://github.com/tobiasbriones/mathsoftware.engineer -->
-
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
      xmlns:lucid="lucid"

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/triangle-for-tangent-point-at-node--to--node-line.svg
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/triangle-for-tangent-point-at-node--to--node-line.svg
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<!-- Copyright (c) 2022 Tobias Briones. All rights reserved. -->
-<!-- SPDX-License-Identifier: MIT -->
-<!-- This file is part of https://github.com/tobiasbriones/mathsoftware.engineer -->
-
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
     "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg height="345.6pt"

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/triangle.py
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/triangle.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 Tobias Briones. All rights reserved.
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: BSD-3-Clause
 # This file is part of https://github.com/mathsoftware/engineer
 
 from ctypes import alignment

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/index.md
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/index.md
@@ -1,5 +1,5 @@
 <!-- Copyright (c) 2022 Tobias Briones. All rights reserved. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
 <!-- This file is part of https://github.com/mathsoftware/engineer -->
 
 # Draw a Tree on Canvas with XY Coordinates (Web)

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/package-lock.json
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "web",
       "version": "1.0.0",
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "devDependencies": {
         "@babel/cli": "^7.18.6",
         "@babel/core": "^7.18.6",

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/package.json
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/package.json
@@ -2,7 +2,7 @@
   "name": "web",
   "description": "Drawing a Tree on Canvas with XY Coordinates (Web)",
   "version": "1.0.0",
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "author": "Tobias Briones",
   "main": "main.ts",
   "private": true,

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/index.html
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/index.html
@@ -1,5 +1,5 @@
 <!-- Copyright (c) 2022 Tobias Briones. All rights reserved. -->
-<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
 <!-- This file is part of https://github.com/mathsoftware/engineer -->
 
 <!DOCTYPE html>

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/main.css
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/main.css
@@ -1,5 +1,5 @@
 /* Copyright (c) 2022 Tobias Briones. All rights reserved. */
-/* SPDX-License-Identifier: MIT */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /* This file is part of https://github.com/mathsoftware/engineer */
 
 body {

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/main.ts
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/main.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 Tobias Briones. All rights reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathsoftware/engineer
 
 import './index.html';

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/model.ts
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/model.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 Tobias Briones. All rights reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathsoftware/engineer
 //
 // This file is also available at https://github.com/repsymo/2dp-repsymo-solver

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/mrm-canvas.ts
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/src/mrm-canvas.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 Tobias Briones. All rights reserved.
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BSD-3-Clause
 // This file is part of https://github.com/mathsoftware/engineer
 //
 // This file is also available at https://github.com/repsymo/2dp-repsymo-solver

--- a/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/webpack/webpack.config.prod.js
+++ b/representation/repsymo/2dp/mrm/feat/drawing-a-tree-on-canvas-with-xy-coordinates/web/webpack/webpack.config.prod.js
@@ -12,7 +12,7 @@ const commonConfig = require('./webpack.config.common');
 
 const copyrightHeader =
 `Copyright (c) 2022 Tobias Briones. All rights reserved.
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: BSD-3-Clause
 This file is part of https://github.com/mathsoftware/engineer`;
 
 const mode = 'production';


### PR DESCRIPTION
Source code from articles is now licensed under the BSD-3-Clause License, and the MIT License is dropped. See [License Change from MIT to BSD-3-Clause for Code Snippets (2023/04/13) | BLOG | mathsofware.engineer](https://blog.mathsoftware.engineer/license-change-from-mit-to-bsd--3--clause-for-code-snippets-2023-04-13) for more details.